### PR TITLE
configs/arch: add powerpc64 e6500 arch

### DIFF
--- a/configs/arch/powerpc64-e6500.config
+++ b/configs/arch/powerpc64-e6500.config
@@ -1,0 +1,2 @@
+BR2_powerpc64=y
+BR2_powerpc_e6500=y


### PR DESCRIPTION
This configuration does not provide a test configuration as full
upstream support for the e6500 arch in QEMU is still on a NXP vendor
branch.  The mainline QEMU as of 2.11 recognizes the e6500 as a
new variant of the e500.  However the mailing list discusses the
user only booting a propietary OS using that emulation.
https://lists.nongnu.org/archive/html/qemu-devel/2017-08/msg02176.html

I tried booting linux with QEMU mainline v2.12.0-rc1 and got an
"exception without defined vector 73" error after "Freeing unused
kernel memory" during Linux 4.15.x boot.

I did however target test a kernel I built using a stable version of
the glibc toolchain on a T2080RDB using 4.15.7. (boot to prompt)

Signed-off-by: Matthew Weber <matthew.weber@rockwellcollins.com>