### PR TITLE
configs/arch: support powerpc e300c3

### DIFF
--- a/configs/arch/powerpc-e300c3.config
+++ b/configs/arch/powerpc-e300c3.config
@@ -1,0 +1,1 @@
+BR2_powerpc_e300c3=y


### PR DESCRIPTION
This configuration provides support for the e300c3, G2, and Power 603e
cores.

A runtime test is not provided as a working QEMU target couldn't be
identified. Testing was attempted with QEMU 2.11 and completed on
hardware.

Signed-off-by: Matt Weber <matt@thewebers.ws>