### PR TITLE
common: add no shell on common fragment

### DIFF
--- a/configs/common.config
+++ b/configs/common.config
@@ -2,5 +2,6 @@ BR2_WGET="wget --passive-ftp -nd -t 3 --no-check-certificate"
 BR2_GNU_MIRROR="http://ftp.gnu.org/pub/gnu"
 BR2_TOOLCHAIN_BUILDROOT_CXX=y
 BR2_INIT_NONE=y
+BR2_SYSTEM_BIN_SH_NONE=y
 # BR2_PACKAGE_BUSYBOX is not set
 # BR2_TARGET_ROOTFS_TAR is not set


### PR DESCRIPTION
If BR2_SYSTEM_BIN_SH_NONE is not set, then dash shell is built
and will show up in the legal information. The dash package is not
used by the toolchain so this should be removed.

Signed-off-by: Ryan Barnett <ryan.barnett@rockwellcollins.com>