### PR TITLE
Enable nios2 m68k risc64 testing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -120,7 +120,8 @@ function set_test_config {
 	;;
     m68k-coldfire)
 	test_defconfig="qemu_m68k_mcf5208_defconfig"
-	# cannot boot under qemu, 2.9 needed
+	# Needs qemu >= 2.9
+	test_board_dir="m68k-mcf5208"
 	;;
     nios2)
         test_defconfig="qemu_nios2_10m50_defconfig"

--- a/build.sh
+++ b/build.sh
@@ -137,6 +137,11 @@ function set_test_config {
         test_defconfig="qemu_ppc64le_pseries_defconfig"
         test_board_dir="ppc64le-pseries"
 	;;
+    riscv64)
+        test_defconfig="qemu_riscv64_virt_defconfig"
+        # Needs qemu >= 2.12
+        test_board_dir="riscv64-virt"
+        ;;
     sh-sh4)
         test_defconfig="qemu_sh4_r2d_defconfig"
         test_board_dir="sh4-r2d"

--- a/build.sh
+++ b/build.sh
@@ -124,7 +124,8 @@ function set_test_config {
 	;;
     nios2)
         test_defconfig="qemu_nios2_10m50_defconfig"
-	# cannot boot under qemu, 2.9 needed
+	# Needs qemu >= 2.9
+	test_board_dir="nios2-10m50"
 	;;
     powerpc64-power8)
         test_defconfig="qemu_ppc64_pseries_defconfig"


### PR DESCRIPTION
This series enable runtime Qemu testing for architecture that requires Qemu >= 2.9 that wasn't present in the docker image (zesty and artful) previously used as build machine.
Now we are using disco Ubuntu image that provide Qemu 3.1.

Note: I tried to add riscv32 architecture but I had some build and runtime issue as soon as I changed the toolchain componants. For now, riscv32 port is not completely stable, lets try latter.

