### PR TITLE
build.sh: set cpu emulation to Nehalem for x86-64-core-i7 target

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -165,6 +165,7 @@ function set_test_config {
         sed -i "s/tty1/ttyS0/" ${buildroot_dir}/configs/${test_defconfig}
         test_board_dir="x86_64"
         test_qemu_append="rw console=ttyS0"
+        test_qemu_args="-cpu Nehalem"
 	;;
     xtensa-lx60)
         test_defconfig="qemu_xtensa_lx60_defconfig"


### PR DESCRIPTION
It make sense to explicitely set the cpu type for x86-64-core-i7 target
(like for mips32r5el or powerpc64-power8) otherwise the qemu emulation
may not provide all assembler instruction emulation.

While testing x86-64-core-i7 with uclibc toolchain, we can't login
due to invalid opcode in uClibc.

   traps: rcS[46] trap invalid opcode ip:7f3adab9d8a6 sp:7ffc008529d0 error:0 in libuClibc-1.0.34.so[7f3adab9c000+52000]

Signed-off-by: Romain Naour <romain.naour@gmail.com>