### PR TITLE
build.sh: add missing RPC option handling

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -340,6 +340,11 @@ function make_br_fragment {
     else
         echo "BR2_TOOLCHAIN_EXTERNAL_HAS_THREADS_NPTL=y" >> ${fragment_file}
     fi
+    if grep "BR2_TOOLCHAIN_HAS_NATIVE_RPC=y" ${configfile} > /dev/null 2>&1; then
+        echo "BR2_TOOLCHAIN_EXTERNAL_INET_RPC=y" >> ${fragment_file}
+    else
+        echo "# BR2_TOOLCHAIN_EXTERNAL_INET_RPC is not set" >> ${fragment_file}
+    fi
     if [ "${libc}" == "glibc" ]; then
         echo "BR2_TOOLCHAIN_EXTERNAL_CUSTOM_GLIBC=y" >> ${fragment_file}
     elif [ "${libc}" == "musl" ]; then


### PR DESCRIPTION
Sun RPC has been removed since glibc 2.32, so the internal
toolchain backend for glibc doesn't set BR2_TOOLCHAIN_HAS_NATIVE_RPC
anymore.

In order to regenerate toolchain-external-bootlin package with or
without BR2_TOOLCHAIN_HAS_NATIVE_RPC, add BR2_TOOLCHAIN_EXTERNAL_INET_RPC
to the generated fragment when needed.

Signed-off-by: Romain Naour <romain.naour@gmail.com>